### PR TITLE
free allocated resources in ex04 and ex07 tests

### DIFF
--- a/courses/cunix/ex04/src/test.c
+++ b/courses/cunix/ex04/src/test.c
@@ -45,14 +45,33 @@ void           test_verif()
 
 void     test_itoa()
 {
+  char *str = my_itoa(0);
+  assert(strcmp(str, "0") == 0);
+  free(str);
 
-  assert(strcmp(my_itoa(0), "0") == 0);
-  assert(strcmp(my_itoa(1), "1") == 0);
-  assert(strcmp(my_itoa(32), "32") == 0);
-  assert(strcmp(my_itoa(12345678), "12345678") == 0);
-  assert(strcmp(my_itoa(-34), "-34") == 0);
-  assert(strcmp(my_itoa(-12345678), "-12345678") == 0);
-  assert(strcmp(my_itoa(-1234567890), "-1234567890") == 0);
+  str = my_itoa(1);
+  assert(strcmp(str, "1") == 0);
+  free(str);
+
+  str = my_itoa(32);
+  assert(strcmp(str, "32") == 0);
+  free(str);
+
+  str = my_itoa(12345678);
+  assert(strcmp(str, "12345678") == 0);
+  free(str);
+  
+  str = my_itoa(-34);
+  assert(strcmp(str, "-34") == 0);
+  free(str);
+
+  str = my_itoa(-12345678);
+  assert(strcmp(str, "-12345678") == 0);
+  free(str);
+
+  str = my_itoa(-1234567890);
+  assert(strcmp(str, "-1234567890") == 0);
+  free(str);
 }
 int   main()
 {

--- a/courses/cunix/ex07/src/test.c
+++ b/courses/cunix/ex07/src/test.c
@@ -120,7 +120,7 @@ int test_pop()
   asprintf(&str, "Test pop: ok");
   list_push(head, str);
 
-  list_pop(&head);
+  free(list_pop(&head));
 
   list_destroy(&head, &test_destroy_push);
 
@@ -137,8 +137,8 @@ int test_shift()
   asprintf(&str, "Test shift: ok");
   list_push(head, str);
 
-  list_shift(&head);
-  list_shift(&head);
+  free(list_shift(&head));
+  free(list_shift(&head));
 
   list_destroy(&head, &test_destroy_push);
 
@@ -164,7 +164,7 @@ int test_remove()
   asprintf(&str, "5");
   list_push(head, str);
 
-  list_remove(&head, 3);
+  free(list_remove(&head, 3));
 
   list_destroy(&head, &test_destroy_push);
 
@@ -208,10 +208,10 @@ int test_global()
   }
 
   for(int i = 0; i < 10000; i++)
-    list_pop(&head);
+    free(list_pop(&head));
 
   for(int i = 0; i < 10000; i++)
-    list_shift(&head);
+    free(list_shift(&head));
 
   list_destroy(&head, &test_destroy_push);
 


### PR DESCRIPTION
``my_itoa`` returns a c-style string and which is allocated inside the function, so memory has to be freed outside. A similar situation with the ``list_shift`` and the ``list_pop``: data is stored in node while those functions return a pointer to it, and nodes are deleted, so data becomes ownerless and has to be freed too.