### PR TITLE
Fix renamed 'atoi' to 'my_atoi'

### DIFF
--- a/courses/cunix/ex04/readme.md
+++ b/courses/cunix/ex04/readme.md
@@ -10,7 +10,7 @@
 * Read all files in include/ src/ and the Makefile before starting anything
 * Create files src/my_atoi.c src/my_itoa.c
 * Implement atoi in a file called my_atoi using the prototype:
-`int atoi(const char *nptr);`
+`int my_atoi(const char *nptr);`
 * Implement itoa in a file called my_itoa using the prototype:
 `char* my_itoa(int nmb);`
 * Run `make test`


### PR DESCRIPTION
User-created function is mentioned in 'tests.c' as 'my_atoi', thus its signature should be 'int my_atoi ...'