### PR TITLE
ex07 test fix

### DIFF
--- a/courses/cunix/ex07/src/test.c
+++ b/courses/cunix/ex07/src/test.c
@@ -7,7 +7,7 @@
 
 void printInt(void *data)
 {
-  printf("%s\n", data);
+  printf("%p\n", data);
 }
 
 void test_destroy_push(void *data)


### PR DESCRIPTION
Running `make test` gives you an error:
```
src/test.c:10:12: error: format ‘%s’ expects argument of type ‘char *’, but argument 2 has type ‘void *’ [-Werror=format=]
   10 | printf("%s\n", data);
      | ~^ ~~~~
      | | |
      | | void *
      | char *
      | %p
```
Changing the formatting specifier for `void *` to `%p` fixes this up.