### PR TITLE
Fixed tests for strcmp

### DIFF
--- a/courses/cunix/ex02/src/test.c
+++ b/courses/cunix/ex02/src/test.c
@@ -10,15 +10,15 @@ void   test_small()
   assert(my_strcmp("", "") == 0);
   assert(my_strcmp("A", "A") == 0);
   assert(my_strcmp("AB", "AB") == 0);
-  assert(my_strcmp("AB", "AC") == -1);
-  assert(my_strcmp("AB", "AA") == 1);
-  assert(my_strcmp("AB", "AD") == -1);
+  assert(my_strcmp("AB", "AC") < 0);
+  assert(my_strcmp("AB", "AA") > 0);
+  assert(my_strcmp("AB", "AD") < 0);
 }
 
 void   test_long()
 {
   assert(my_strcmp("HELLO WORLD", "HELLA WORLD") > 0);
-  assert(my_strcmp("HELLO WORLD", "HELL WORLD") == 1);
+  assert(my_strcmp("HELLO WORLD", "HELL WORLD") > 0);
 }
 
 int   main()


### PR DESCRIPTION
Function strcmp in case of not equal strings returns difference between first characters that differs.
DESCRIPTION
       The  strcmp()  function compares the two strings s1 and s2.  It returns
       an integer less than, equal to, or greater than zero if  s1  is  found,
       respectively, to be less than, to match, or be greater than s2.
