### PR TITLE
Fixed compile error due to bad test

### DIFF
--- a/courses/cunix/ex07/src/test.c
+++ b/courses/cunix/ex07/src/test.c
@@ -7,7 +7,7 @@
 
 void printInt(void *data)
 {
-  printf("%s\n", data);
+  printf("%s\n", (char *)data);
 }
 
 void test_destroy_push(void *data)


### PR DESCRIPTION
Implicit cast of (void *) to (char *) cause compilation error.